### PR TITLE
Updates to support Start Group and End Groups

### DIFF
--- a/example_group_test.go
+++ b/example_group_test.go
@@ -1,0 +1,88 @@
+package protoscan
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+func Example_groups() {
+
+	data := []byte{}
+
+	data = protowire.AppendTag(data, 200, WireTypeStartGroup)
+	data = protowire.AppendTag(data, 300, WireType64bit)
+	data = protowire.AppendFixed64(data, 100_100_100)
+	data = protowire.AppendTag(data, 400, WireTypeVarint)
+	data = protowire.AppendVarint(data, 100_100)
+	data = protowire.AppendTag(data, 200, WireTypeEndGroup)
+
+	var (
+		groupFieldNum = 200
+		groupData     []byte
+	)
+
+	msg := New(data)
+	for msg.Next() {
+		if msg.FieldNumber() == groupFieldNum && msg.WireType() == WireTypeStartGroup {
+			start := msg.Index
+			end := msg.Index
+			for msg.Next() {
+				msg.Skip()
+				if msg.FieldNumber() == groupFieldNum && msg.WireType() == WireTypeEndGroup {
+					break
+				}
+				end = msg.Index
+			}
+			// groupData would be the raw protobuf encoded bytes of the fields in the group.
+			groupData = msg.Data[start:end]
+		}
+	}
+
+	fmt.Printf("data length: %d\n", len(data))
+	fmt.Printf("group data length: %v\n", len(groupData))
+
+	// Output:
+	// data length: 19
+	// group data length: 15
+}
+
+func Example_emptyGroup() {
+	data := []byte{}
+
+	data = protowire.AppendTag(data, 100, WireType64bit)
+	data = protowire.AppendFixed64(data, 100_100_100)
+	data = protowire.AppendTag(data, 200, WireTypeStartGroup)
+	data = protowire.AppendTag(data, 200, WireTypeEndGroup)
+	data = protowire.AppendTag(data, 400, WireTypeVarint)
+	data = protowire.AppendVarint(data, 100_100)
+
+	var (
+		groupFieldNum = 200
+		groupData     []byte
+	)
+
+	msg := New(data)
+	for msg.Next() {
+		if msg.FieldNumber() == groupFieldNum && msg.WireType() == WireTypeStartGroup {
+			start := msg.Index
+			end := msg.Index
+			for msg.Next() {
+				msg.Skip()
+				if msg.FieldNumber() == groupFieldNum && msg.WireType() == WireTypeEndGroup {
+					break
+				}
+				end = msg.Index
+			}
+			// groupData would be the raw protobuf encoded bytes of the fields in the group.
+			groupData = msg.Data[start:end]
+		}
+	}
+
+	fmt.Printf("data length: %d\n", len(data))
+	fmt.Printf("group data length: %v\n", len(groupData))
+
+	// Output:
+	// data length: 19
+	// group data length: 0
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/paulmach/protoscan
 
 go 1.15
 
-require google.golang.org/protobuf v1.26.0
+require google.golang.org/protobuf v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -6,3 +6,5 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
+google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=

--- a/iterator.go
+++ b/iterator.go
@@ -22,11 +22,11 @@ func (m *Message) Iterator(iter *Iterator) (*Iterator, error) {
 		iter = &Iterator{}
 	}
 	iter.base = base{
-		data:  m.data[m.index : m.index+l],
-		index: 0,
+		Data:  m.Data[m.Index : m.Index+l],
+		Index: 0,
 	}
 	iter.fieldNumber = m.fieldNumber
-	m.index += l
+	m.Index += l
 
 	return iter, nil
 }
@@ -36,7 +36,7 @@ func (m *Message) Iterator(iter *Iterator) (*Iterator, error) {
 // This method does NOT need to be called, reading a value automatically
 // moves in the index forward. This behavior is different than Message.Next().
 func (i *Iterator) HasNext() bool {
-	return i.base.index < len(i.base.data)
+	return i.base.Index < len(i.base.Data)
 }
 
 // Skip will move the interator forward 'count' value(s) without actually reading it.
@@ -48,17 +48,17 @@ func (i *Iterator) HasNext() bool {
 func (i *Iterator) Skip(wireType int, count int) {
 	if wireType == WireTypeVarint {
 		for j := 0; j < count; j++ {
-			for i.data[i.index] >= 128 {
-				i.index++
+			for i.Data[i.Index] >= 128 {
+				i.Index++
 			}
-			i.index++
+			i.Index++
 		}
 		return
 	} else if wireType == WireType32bit {
-		i.index += 4 * count
+		i.Index += 4 * count
 		return
 	} else if wireType == WireType64bit {
-		i.index += 8 * count
+		i.Index += 8 * count
 		return
 	}
 
@@ -73,7 +73,7 @@ func (i *Iterator) Skip(wireType int, count int) {
 func (i *Iterator) Count(wireType int) int {
 	if wireType == WireTypeVarint {
 		var count int
-		for _, b := range i.data {
+		for _, b := range i.Data {
 			if b < 128 {
 				count++
 			}
@@ -82,10 +82,10 @@ func (i *Iterator) Count(wireType int) int {
 		return count
 	}
 	if wireType == WireType32bit {
-		return len(i.base.data) / 4
+		return len(i.base.Data) / 4
 	}
 	if wireType == WireType64bit {
-		return len(i.base.data) / 8
+		return len(i.base.Data) / 8
 	}
 
 	panic("invalid wire type for a packed repeated field")

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -574,7 +574,7 @@ func BenchmarkRepeatedInt64(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		msg.index = 0
+		msg.Index = 0
 		for msg.Next() {
 			switch msg.FieldNumber() {
 			case 4:
@@ -607,7 +607,7 @@ func BenchmarkIterateInt64(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		msg.index = 0
+		msg.Index = 0
 		for msg.Next() {
 			switch msg.FieldNumber() {
 			case 4:
@@ -650,7 +650,7 @@ func BenchmarkIterateSkip_single(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		msg.index = 0
+		msg.Index = 0
 		for msg.Next() {
 			switch msg.FieldNumber() {
 			case 4:
@@ -690,7 +690,7 @@ func BenchmarkIterateSkip_all(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		msg.index = 0
+		msg.Index = 0
 		for msg.Next() {
 			switch msg.FieldNumber() {
 			case 4:

--- a/repeated.go
+++ b/repeated.go
@@ -24,8 +24,8 @@ func (m *Message) RepeatedFloat(buf []float32) ([]float32, error) {
 		buf = make([]float32, 0, l/4)
 	}
 
-	postIndex := m.index + l
-	for m.index < postIndex {
+	postIndex := m.Index + l
+	for m.Index < postIndex {
 		v, err := m.Float()
 		if err != nil {
 			return nil, err
@@ -59,8 +59,8 @@ func (m *Message) RepeatedDouble(buf []float64) ([]float64, error) {
 		buf = make([]float64, 0, l/8)
 	}
 
-	postIndex := m.index + l
-	for m.index < postIndex {
+	postIndex := m.Index + l
+	for m.Index < postIndex {
 		v, err := m.Double()
 		if err != nil {
 			return nil, err
@@ -94,8 +94,8 @@ func (m *Message) RepeatedInt32(buf []int32) ([]int32, error) {
 		buf = make([]int32, 0, m.count(l))
 	}
 
-	postIndex := m.index + l
-	for m.index < postIndex {
+	postIndex := m.Index + l
+	for m.Index < postIndex {
 		v, err := m.Int32()
 		if err != nil {
 			return nil, err
@@ -129,8 +129,8 @@ func (m *Message) RepeatedInt64(buf []int64) ([]int64, error) {
 		buf = make([]int64, 0, m.count(l))
 	}
 
-	postIndex := m.index + l
-	for m.index < postIndex {
+	postIndex := m.Index + l
+	for m.Index < postIndex {
 		v, err := m.Int64()
 		if err != nil {
 			return nil, err
@@ -164,8 +164,8 @@ func (m *Message) RepeatedUint32(buf []uint32) ([]uint32, error) {
 		buf = make([]uint32, 0, m.count(l))
 	}
 
-	postIndex := m.index + l
-	for m.index < postIndex {
+	postIndex := m.Index + l
+	for m.Index < postIndex {
 		v, err := m.Uint32()
 		if err != nil {
 			return nil, err
@@ -199,8 +199,8 @@ func (m *Message) RepeatedUint64(buf []uint64) ([]uint64, error) {
 		buf = make([]uint64, 0, m.count(l))
 	}
 
-	postIndex := m.index + l
-	for m.index < postIndex {
+	postIndex := m.Index + l
+	for m.Index < postIndex {
 		v, err := m.Uint64()
 		if err != nil {
 			return nil, err
@@ -234,8 +234,8 @@ func (m *Message) RepeatedSint32(buf []int32) ([]int32, error) {
 		buf = make([]int32, 0, m.count(l))
 	}
 
-	postIndex := m.index + l
-	for m.index < postIndex {
+	postIndex := m.Index + l
+	for m.Index < postIndex {
 		v, err := m.Sint32()
 		if err != nil {
 			return nil, err
@@ -269,8 +269,8 @@ func (m *Message) RepeatedSint64(buf []int64) ([]int64, error) {
 		buf = make([]int64, 0, m.count(l))
 	}
 
-	postIndex := m.index + l
-	for m.index < postIndex {
+	postIndex := m.Index + l
+	for m.Index < postIndex {
 		v, err := m.Sint64()
 		if err != nil {
 			return nil, err
@@ -304,8 +304,8 @@ func (m *Message) RepeatedFixed32(buf []uint32) ([]uint32, error) {
 		buf = make([]uint32, 0, l/4)
 	}
 
-	postIndex := m.index + l
-	for m.index < postIndex {
+	postIndex := m.Index + l
+	for m.Index < postIndex {
 		v, err := m.Fixed32()
 		if err != nil {
 			return nil, err
@@ -339,8 +339,8 @@ func (m *Message) RepeatedFixed64(buf []uint64) ([]uint64, error) {
 		buf = make([]uint64, 0, l/8)
 	}
 
-	postIndex := m.index + l
-	for m.index < postIndex {
+	postIndex := m.Index + l
+	for m.Index < postIndex {
 		v, err := m.Fixed64()
 		if err != nil {
 			return nil, err
@@ -374,8 +374,8 @@ func (m *Message) RepeatedSfixed32(buf []int32) ([]int32, error) {
 		buf = make([]int32, 0, l/4)
 	}
 
-	postIndex := m.index + l
-	for m.index < postIndex {
+	postIndex := m.Index + l
+	for m.Index < postIndex {
 		v, err := m.Sfixed32()
 		if err != nil {
 			return nil, err
@@ -409,8 +409,8 @@ func (m *Message) RepeatedSfixed64(buf []int64) ([]int64, error) {
 		buf = make([]int64, 0, l/8)
 	}
 
-	postIndex := m.index + l
-	for m.index < postIndex {
+	postIndex := m.Index + l
+	for m.Index < postIndex {
 		v, err := m.Sfixed64()
 		if err != nil {
 			return nil, err
@@ -444,8 +444,8 @@ func (m *Message) RepeatedBool(buf []bool) ([]bool, error) {
 		buf = make([]bool, 0, l)
 	}
 
-	postIndex := m.index + l
-	for m.index < postIndex {
+	postIndex := m.Index + l
+	for m.Index < postIndex {
 		v, err := m.Bool()
 		if err != nil {
 			return nil, err

--- a/scalar.go
+++ b/scalar.go
@@ -9,24 +9,24 @@ import (
 // Fixed32 reads a fixed 4 byte value as a uint32. This proto type is
 // more efficient than uint32 if values are often greater than 2^28.
 func (b *base) Fixed32() (uint32, error) {
-	if len(b.data) < b.index+4 {
+	if len(b.Data) < b.Index+4 {
 		return 0, io.ErrUnexpectedEOF
 	}
 
-	v := binary.LittleEndian.Uint32(b.data[b.index:])
-	b.index += 4
+	v := binary.LittleEndian.Uint32(b.Data[b.Index:])
+	b.Index += 4
 	return v, nil
 }
 
 // Fixed64 reads a fixed 8 byte value as an uint64. This proto type is
 // more efficient than uint64 if values are often greater than 2^56.
 func (b *base) Fixed64() (uint64, error) {
-	if len(b.data) < b.index+8 {
+	if len(b.Data) < b.Index+8 {
 		return 0, io.ErrUnexpectedEOF
 	}
 
-	v := binary.LittleEndian.Uint64(b.data[b.index:])
-	b.index += 8
+	v := binary.LittleEndian.Uint64(b.Data[b.Index:])
+	b.Index += 8
 	return v, nil
 }
 
@@ -49,7 +49,7 @@ func (b *base) Varint32() (uint32, error) {
 	var v uint32
 	var err error
 
-	b.index, v, err = varint32(b.data, b.index)
+	b.Index, v, err = varint32(b.Data, b.Index)
 	return v, err
 }
 
@@ -83,7 +83,7 @@ func (b *base) Varint64() (uint64, error) {
 	var v uint64
 	var err error
 
-	b.index, v, err = varint64(b.data, b.index)
+	b.Index, v, err = varint64(b.Data, b.Index)
 	return v, err
 }
 
@@ -129,7 +129,7 @@ func (b *base) Float() (float32, error) {
 func (b *base) Int32() (int32, error) {
 	var v uint64
 	var err error
-	b.index, v, err = varint64(b.data, b.index)
+	b.Index, v, err = varint64(b.Data, b.Index)
 
 	return int32(v), err
 }
@@ -139,7 +139,7 @@ func (b *base) Int32() (int32, error) {
 func (b *base) Int64() (int64, error) {
 	var v uint64
 	var err error
-	b.index, v, err = varint64(b.data, b.index)
+	b.Index, v, err = varint64(b.Data, b.Index)
 
 	return int64(v), err
 }
@@ -149,7 +149,7 @@ func (b *base) Uint32() (uint32, error) {
 	var v uint32
 	var err error
 
-	b.index, v, err = varint32(b.data, b.index)
+	b.Index, v, err = varint32(b.Data, b.Index)
 	return v, err
 }
 
@@ -158,7 +158,7 @@ func (b *base) Uint64() (uint64, error) {
 	var v uint64
 	var err error
 
-	b.index, v, err = varint64(b.data, b.index)
+	b.Index, v, err = varint64(b.Data, b.Index)
 	return v, err
 }
 
@@ -168,7 +168,7 @@ func (b *base) Sint32() (int32, error) {
 	var v uint64
 	var err error
 
-	b.index, v, err = varint64(b.data, b.index)
+	b.Index, v, err = varint64(b.Data, b.Index)
 	return int32(unZig64(v)), err
 }
 
@@ -178,22 +178,22 @@ func (b *base) Sint64() (int64, error) {
 	var v uint64
 	var err error
 
-	b.index, v, err = varint64(b.data, b.index)
+	b.Index, v, err = varint64(b.Data, b.Index)
 	return unZig64(v), err
 }
 
 // Bool is encoded as 0x01 or 0x00 plus the field+type prefix byte. 2 bytes total.
 func (b *base) Bool() (bool, error) {
-	if len(b.data) <= b.index {
+	if len(b.Data) <= b.Index {
 		return false, io.ErrUnexpectedEOF
 	}
-	if d := b.data[b.index]; d&0x80 == 0 {
-		b.index++
+	if d := b.Data[b.Index]; d&0x80 == 0 {
+		b.Index++
 		return d == 1, nil
 	}
 	var v uint64
 	var err error
-	b.index, v, err = varint64(b.data, b.index)
+	b.Index, v, err = varint64(b.Data, b.Index)
 	return v == 1, err
 }
 
@@ -212,8 +212,8 @@ func (m *Message) Bytes() ([]byte, error) {
 		return nil, err
 	}
 
-	b := m.data[m.index : m.index+l]
-	m.index += l
+	b := m.Data[m.Index : m.Index+l]
+	m.Index += l
 	return b, nil
 }
 

--- a/scalar_test.go
+++ b/scalar_test.go
@@ -669,7 +669,7 @@ func BenchmarkVarint32(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		m.index = 0
+		m.Index = 0
 		_, err := m.Varint32()
 		if err != nil {
 			b.Fatal(err)
@@ -693,7 +693,7 @@ func BenchmarkInt64(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		m.index = 0
+		m.Index = 0
 		_, err := m.Int64()
 		if err != nil {
 			b.Fatal(err)
@@ -717,7 +717,7 @@ func BenchmarkBool(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		m.index = 0
+		m.Index = 0
 		_, err := m.Bool()
 		if err != nil {
 			b.Fatal(err)


### PR DESCRIPTION
* export Message.Data and Index attributes
* add information about start/end groups to readme, and example

See the readme updates below and examples for more information.